### PR TITLE
Use env to determine where python lives

### DIFF
--- a/wp
+++ b/wp
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import os


### PR DESCRIPTION
Use the env command to determine which python to use. Useful if it's been installed with Homebrew or others.